### PR TITLE
release version 0.1.1 and add per-crate readme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,7 +455,7 @@ dependencies = [
 
 [[package]]
 name = "thorin-dwp"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "gimli",
  "indexmap",
@@ -465,7 +465,7 @@ dependencies = [
 
 [[package]]
 name = "thorin-dwp-bin"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "anyhow",
  "memmap2",

--- a/thorin-bin/Cargo.toml
+++ b/thorin-bin/Cargo.toml
@@ -6,13 +6,13 @@ description = "Merge DWARF objects and packages into DWARF packages"
 homepage = "https://github.com/davidtwco/thorin"
 keywords = ["dwarf", "split-dwarf", "dwarf-package", "dwarf-object", "dwp"]
 license = "MIT OR Apache-2.0"
-readme = "../README.md"
+readme = "README.md"
 repository = "https://github.com/davidtwco/thorin"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]
-thorin-dwp = { version = "0.1.0", path = "../thorin" }
+thorin-dwp = { version = "0.1.1", path = "../thorin" }
 
 anyhow = "1.0.51"
 memmap2 = "0.5.0"

--- a/thorin-bin/README.md
+++ b/thorin-bin/README.md
@@ -3,56 +3,37 @@
 DWARF objects (`*.dwo` files; or `*.o` files with `.dwo` sections), supporting both the pre-standard
 GNU extension format for DWARF packages and the standardized format introduced in DWARF 5.
 
-See the README documents of the [`thorin` crate](thorin/README.md) and the
-[`thorin-bin` crate](thorin-bin/README.md) for usage details of the library and binary interfaces
-respectively.
-
-## Contributing to `thorin`
-If you want help or mentorship, reach out to us in a GitHub issue, or ask `davidtwco` on the
-[Rust Zulip instance](https://rust-lang.zulipchat.com/).
-
-`thorin` should always build on stable `rustc`. To build `thorin`:
+## Usage
+`thorin` can read input DWARF objects from executables or can package arbitrary input dwarf
+objects (including DWARF objects in archive files, such as Rust rlibs)! Install `thorin` using
+`cargo`:
 
 ```shell-session
-$ cargo build
+$ cargo install thorin-dwp-bin
+$ thorin --help
+thorin 0.1.1
+merge dwarf objects into dwarf packages
+
+USAGE:
+    thorin [OPTIONS] [--] [inputs]...
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -e, --exec <executables>...    Specify path to executables to read list of dwarf objects from
+    -o, --output <output>          Specify path to write the dwarf package to [default: -]
+
+ARGS:
+    <inputs>...    Specify path to input dwarf objects and packages
 ```
 
-To run the tests, first install the relevant dependencies:
+If the input objects are of DWARF version 5 or greater, then the output package will be in DWARF 5
+format. For version 4 and below, the GNU Extension format will be used for the output package.
 
-```shell-session
-$ apt install --no-install-recommends --yes llvm-13 llvm-13-tools
-$ pip install lit
-```
-
-Next, run the `lit` testsuite (replacing `/path/to/llvm/bin` with the correct path to your LLVM
-installation, if required):
-
-```shell-session
-$ cargo build # in debug mode..
-$ lit -v --path "$PWD/target/debug/:/path/to/llvm/bin/" ./tests
-$ cargo build --release # ..or in release mode
-$ lit -v --path "$PWD/target/release/:/path/to/llvm/bin/" ./tests
-```
-
-We use `rustfmt` to automatically format and style all of our code. To install and use `rustfmt`:
-
-```shell-session
-$ rustup component add rustfmt
-$ cargo fmt
-```
-
-### Filing an issue
-Think you've found a bug? File an issue! To help us understand and reproduce the
-issue, provide us with:
-
-* The (preferably minimal) test case
-* Steps to reproduce the issue using the test case
-* The expected result of following those steps
-* The actual result of following those steps
-
-Definitely file an issue if you see an unexpected panic originating from within `thorin`!
-`thorin` should never panic unless it is explicitly documented to panic in the specific
-circumstances provided.
+## Stability
+`thorin`'s command-line interface is intended to be stable and have limited breaking changes.
 
 <br>
 

--- a/thorin/Cargo.toml
+++ b/thorin/Cargo.toml
@@ -6,9 +6,9 @@ description = "Library for building DWARF packages from input DWARF objects and 
 homepage = "https://docs.rs/thorin-dwp"
 keywords = ["dwarf", "split-dwarf", "dwarf-package", "dwarf-object", "dwp"]
 license = "MIT OR Apache-2.0"
-readme = "../README.md"
+readme = "README.md"
 repository = "https://github.com/davidtwco/thorin"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]

--- a/thorin/README.md
+++ b/thorin/README.md
@@ -3,56 +3,19 @@
 DWARF objects (`*.dwo` files; or `*.o` files with `.dwo` sections), supporting both the pre-standard
 GNU extension format for DWARF packages and the standardized format introduced in DWARF 5.
 
-See the README documents of the [`thorin` crate](thorin/README.md) and the
-[`thorin-bin` crate](thorin-bin/README.md) for usage details of the library and binary interfaces
-respectively.
+## Usage
+To use `thorin` in your own project, add it to your `Cargo.toml`:
 
-## Contributing to `thorin`
-If you want help or mentorship, reach out to us in a GitHub issue, or ask `davidtwco` on the
-[Rust Zulip instance](https://rust-lang.zulipchat.com/).
-
-`thorin` should always build on stable `rustc`. To build `thorin`:
-
-```shell-session
-$ cargo build
+```toml
+thorin-dwp = "0.1.1"
 ```
 
-To run the tests, first install the relevant dependencies:
+See the [`thorin-bin`](../thorin-bin/README.md) crate for an example of using `thorin`'s library
+interface.
 
-```shell-session
-$ apt install --no-install-recommends --yes llvm-13 llvm-13-tools
-$ pip install lit
-```
-
-Next, run the `lit` testsuite (replacing `/path/to/llvm/bin` with the correct path to your LLVM
-installation, if required):
-
-```shell-session
-$ cargo build # in debug mode..
-$ lit -v --path "$PWD/target/debug/:/path/to/llvm/bin/" ./tests
-$ cargo build --release # ..or in release mode
-$ lit -v --path "$PWD/target/release/:/path/to/llvm/bin/" ./tests
-```
-
-We use `rustfmt` to automatically format and style all of our code. To install and use `rustfmt`:
-
-```shell-session
-$ rustup component add rustfmt
-$ cargo fmt
-```
-
-### Filing an issue
-Think you've found a bug? File an issue! To help us understand and reproduce the
-issue, provide us with:
-
-* The (preferably minimal) test case
-* Steps to reproduce the issue using the test case
-* The expected result of following those steps
-* The actual result of following those steps
-
-Definitely file an issue if you see an unexpected panic originating from within `thorin`!
-`thorin` should never panic unless it is explicitly documented to panic in the specific
-circumstances provided.
+## Stability
+`thorin`'s library interface is intended for use by `rustc` for its *Split DWARF* support, it
+currently comes with no stability guarantees and may change at any time.
 
 <br>
 


### PR DESCRIPTION
Instead of using the same README for both the library and binary crates, use a separate specific README for each. Upgrade the version to 0.1.1, including nagisa's patches (#10).